### PR TITLE
Added newline when dumping json files to conform to POSIX line 

### DIFF
--- a/src/post_processor/util.py
+++ b/src/post_processor/util.py
@@ -39,6 +39,7 @@ def load_json(file_path: str) -> dict:
 def dump_json(content: dict, file_path: str):
     with open(file_path, 'w') as outfile:
         json.dump(content, outfile, indent=4, sort_keys=True)
+        outfile.write("\n")
 
 
 def uuid5(name):


### PR DESCRIPTION
Applying Hannes' comment: https://github.com/HumanCellAtlas/schema-test-data/pull/8#discussion_r607407386

https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline

ebi-ait/dcp-ingest-central#273