### PR TITLE
create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# The branch protection rule require reviews from the people on this list.
+# see List in https://github.com/HumanCellAtlas/dcp2/blob/main/docs/dcp2_operating_procedures.rst#designated-reviewers
+
+* @amnonkhen       # Amnon (EBI)
+* @ESapenaVentura  # Enrique (EBI)
+* @hannes-ucsc     # Hannes (UCSC)
+* @ncalvanese1     # Nate (Broad)
+* @NoopDog         # Dave (UCSC)


### PR DESCRIPTION
Create a code owners list to enforce PR reviews by the people listed in https://github.com/HumanCellAtlas/dcp2/blob/main/docs/dcp2_operating_procedures.rst#designated-reviewers.
This is in conjunction with employing [branch protection rules](https://github.com/HumanCellAtlas/schema-test-data/settings/branch_protection_rules/28744976): mandatory PRS, min required reviews, reviews by code owners required

see related dcp2 spec update HumanCellAtlas/dcp2#65